### PR TITLE
Simplify Dockerfile by using dropins - no server.xml is needed

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -96,25 +96,9 @@ The first stage copies over the Spring Boot application [hotspot=copyJar]`guide-
 and then use the Open Liberty [hotspot=springBootUtility]`springBootUtility` command to thin the application. 
 For more information, you can check out the https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_command_sbutility.html[official springBootUtility page^].
 
-The next stage starts from the [hotspot=OLimage2 file=0]`Open Liberty Docker image`, then copies the [hotspot=20]`server`
-configuration file, the Spring Boot dependent library JARs at [hotspot=libcache file=0]`lib.index.cache`, and 
+The next stage starts from the [hotspot=OLimage2 file=0]`Open Liberty Docker image`, then copies
+the Spring Boot dependent library JARs at [hotspot=libcache file=0]`lib.index.cache`, and
 the thin application [hotspot=thinjar file=0]`thin-guide-spring-boot-0.1.0.jar` which were generated in the first stage.
-
-To get the Spring Boot application running, the Liberty server needs to be correctly configured.
-
-[role="code_command hotspot file=1", subs="quotes"] 
----- 
-#Create the `server.xml`.#
-`src/main/liberty/config/server.xml`
----- 
-
-The [hotspot=servlet file=1]`servlet` and [hotspot=springboot file=1]`springBoot` features are required for the Liberty server to run the Spring Boot application.  The application port is specified as [hotspot=httpport file=1]`9080` and the application is configured as a [hotspot=springBootApplication file=1]`<springBootApplication />`.
-
-server.xml
-[source, XML, linenums, role='code_column'] 
----- 
-include::finish/src/main/liberty/config/server.xml[]
----- 
 
 Next, build the Docker image with the following command.
 [role='command']
@@ -199,12 +183,13 @@ However, in order to install the Spring Boot application to the downloaded Open 
 To get the Spring Boot application running, the Liberty server needs to be correctly configured.
 By default, the `liberty-maven-plugin` will pick up the server configuration file from the `src/main/liberty/config` directory.
 
-Create the server.xml if you didn't in the previous section.
 [role="code_command hotspot file=1", subs="quotes"] 
 ---- 
 #Create the `server.xml`.#
 `src/main/liberty/config/server.xml`
 ---- 
+
+The [hotspot=servlet file=1]`servlet` and [hotspot=springboot file=1]`springBoot` features are required for the Liberty server to run the Spring Boot application.  The application port is specified as [hotspot=httpport file=1]`9080` and the application is configured as a [hotspot=springBootApplication file=1]`<springBootApplication />`.
 
 server.xml
 [source, XML, linenums, role='code_column'] 

--- a/finish/Dockerfile
+++ b/finish/Dockerfile
@@ -17,11 +17,10 @@ RUN springBootUtility thin \
 # tag::OLimage2[]
 FROM open-liberty:springBoot2
 # end::OLimage2[]
-COPY --chown=1001:0 src/main/liberty/config/server.xml /config
 # tag::libcache[]
 COPY --from=staging /staging/lib.index.cache /lib.index.cache
 # end::libcache[]
 # tag::thinjar[]
 COPY --from=staging /staging/thin-guide-spring-boot-0.1.0.jar \
-                    /config/apps/thin-guide-spring-boot-0.1.0.jar
+                    /config/dropins/spring/thin-guide-spring-boot-0.1.0.jar
 # end::thinjar[]


### PR DESCRIPTION
No server.xml is needed if the Dockerfile copies the thin JAR to `config/dropins/spring`. This simplifies the number of steps a user needs to take by avoiding creating the server.xml at this stage, and it reduces the number of layers in the Dockerfile.